### PR TITLE
Format yaml fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.8.8.1:
+* Format-YAML now supports -Indent (Fixes #59)
+* Format-YAML now supports all primitive types (Fixes #58). Thanks @dfinke!
+---
+
 ## 1.8.8:
 * Write-EZFormatFile generates scripts that output files.  Fixes #56 and #43.
 ---

--- a/EZOut.format.ps1xml
+++ b/EZOut.format.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.8.8: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.8.8.1: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <SelectionSets>
     <SelectionSet>

--- a/EZOut.psd1
+++ b/EZOut.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     ModuleToProcess = 'EZOut.psm1'
-    ModuleVersion = '1.8.8'
+    ModuleVersion = '1.8.8.1'
     GUID = 'cef786f0-8a0b-4a5d-a2c6-b433095354cd'
     Author = 'James Brundage'
     CompanyName = 'Start-Automating'
@@ -42,6 +42,11 @@
 
             Tags = '.ps1xml', 'Format','Output','Types', 'Colorized'
             ReleaseNotes = @'
+## 1.8.8.1:
+* Format-YAML now supports -Indent (Fixes #59)
+* Format-YAML now supports all primitive types (Fixes #58). Thanks @dfinke!
+---
+
 ## 1.8.8:
 * Write-EZFormatFile generates scripts that output files.  Fixes #56 and #43.
 ---

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -1169,6 +1169,10 @@ b: 2.1
 c: c
 d:
   k: v
+*
 '@
-    }    
+    }
+    it 'Can indent yaml' {
+        Format-YAML -InputObject @{a='a'} -Indent 4 | Should -Match '(?m)^\s{4}'
+    }
 }

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -1162,13 +1162,7 @@ describe 'Format-Object' {
 describe 'Format-YAML' {
     it 'Formats an object as YAML' {
         ([Ordered]@{a=1;b=2.1;c='c';d=@{k='v'}} | Format-YAML).Trim() | 
-            Should -BeLike '
-a: 1
-b: 2.1
-c: c
-d:*
-  k: v
-'.Trim()
+            Should -BeLike '*a:*1*b:*2.1*c:*c*d:*k:*v*'
     }
     it 'Can indent yaml' {
         Format-YAML -InputObject @{a='a'} -Indent 4 | Should -Match '(?m)^\s{4}'

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -1161,16 +1161,14 @@ describe 'Format-Object' {
 
 describe 'Format-YAML' {
     it 'Formats an object as YAML' {
-        [Ordered]@{a=1;b=2.1;c='c';d=@{k='v'}} | Format-YAML | 
-            Should -BeLike @'
-*
+        ([Ordered]@{a=1;b=2.1;c='c';d=@{k='v'}} | Format-YAML).Trim() | 
+            Should -BeLike '
 a: 1
 b: 2.1
 c: c
-d:
+d:*
   k: v
-*
-'@
+'.Trim()
     }
     it 'Can indent yaml' {
         Format-YAML -InputObject @{a='a'} -Indent 4 | Should -Match '(?m)^\s{4}'

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -1158,3 +1158,17 @@ describe 'Format-Object' {
         100 | Format-Object -HeatMapMax 100 -HeatMapHot 0xff0000 | Should -be '#ff0000'
     }
 }
+
+describe 'Format-YAML' {
+    it 'Formats an object as YAML' {
+        [Ordered]@{a=1;b=2.1;c='c';d=@{k='v'}} | Format-YAML | 
+            Should -BeLike @'
+*
+a: 1
+b: 2.1
+c: c
+d:
+  k: v
+'@
+    }    
+}

--- a/Format-YAML.ps1
+++ b/Format-YAML.ps1
@@ -16,7 +16,7 @@ function Format-YAML
     # The InputObject.
     [Parameter(ValueFromPipeline)]
     [PSObject]
-    $inputObject,
+    $InputObject,
 
     # If set, will make a YAML header by adding a YAML Document tag above and below output.
     [Alias('YAMLDocument')]
@@ -64,7 +64,7 @@ function Format-YAML
                     }
                     return # Once the string has been emitted, return.
                 }
-                if ( [int], [float], [bool] -contains $Object.GetType() ) { # If it is an [int] or [float] or [bool]
+                if ( $Object.GetType().IsPrimitive ) { # If it is a primitive type
                     "$Object".ToLower()  # Emit it in lowercase.
                     if ($Parent -is [Collections.IList]) {
                         [Environment]::NewLine
@@ -102,14 +102,12 @@ function Format-YAML
                     foreach ($Obj in $Object) { 
                         $allPrimitive = $allPrimitive -band (
                             $Obj -is [string] -or 
-                            $obj -is [int] -or 
-                            $obj -is [float] -or 
-                            $obj -is [bool]
+                            $obj.GetType().IsPrimitive
                         ) 
                     }
                     if ($parent -and -not $allPrimitive) {
                         $Indent += 2
-                    }            
+                    }
                 }
             
             

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.8.8.1:
+* Format-YAML now supports -Indent (Fixes #59)
+* Format-YAML now supports all primitive types (Fixes #58). Thanks @dfinke!
+---
+
 ## 1.8.8:
 * Write-EZFormatFile generates scripts that output files.  Fixes #56 and #43.
 ---

--- a/docs/Format-Markdown.md
+++ b/docs/Format-Markdown.md
@@ -64,6 +64,9 @@ Valid Values:
 * Right
 * Center
 * 
+
+
+
 |Type            |Requried|Postion|PipelineInput        |
 |----------------|--------|-------|---------------------|
 |```[String[]]```|false   |2      |true (ByPropertyName)|

--- a/docs/Format-YAML.md
+++ b/docs/Format-YAML.md
@@ -23,7 +23,7 @@ Format-Yaml -InputObject @("a", "b", "c")
 
 ---
 ### Parameters
-#### **inputObject**
+#### **InputObject**
 
 The InputObject.
 
@@ -43,9 +43,15 @@ If set, will make a YAML header by adding a YAML Document tag above and below ou
 |--------------|--------|-------|-------------|
 |```[Switch]```|false   |named  |false        |
 ---
+#### **Indent**
+
+|Type         |Requried|Postion|PipelineInput|
+|-------------|--------|-------|-------------|
+|```[Int32]```|false   |2      |false        |
+---
 ### Syntax
 ```PowerShell
-Format-YAML [[-inputObject] <PSObject>] [-YamlHeader] [<CommonParameters>]
+Format-YAML [[-InputObject] <PSObject>] [-YamlHeader] [[-Indent] <Int32>] [<CommonParameters>]
 ```
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ You can install EZOut from the PowerShell Gallery.  Simply:
 ~~~PowerShell
 Install-Module EZOut -AllowClobber -Scope CurrentUser
 ~~~
+
 ### Understanding PowerShell Formatting
 
 Unlike many languages, PowerShell has a formatting engine built into the box.  
@@ -180,6 +181,9 @@ EZOut ships with a rich PSModuleInfo formatter, which will display the module na
 ~~~PowerShell
 Get-Module EZOut | Format-Custom
 ~~~
+
+
+
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,6 @@ You can install EZOut from the PowerShell Gallery.  Simply:
 ~~~PowerShell
 Install-Module EZOut -AllowClobber -Scope CurrentUser
 ~~~
-
 ### Understanding PowerShell Formatting
 
 Unlike many languages, PowerShell has a formatting engine built into the box.  
@@ -181,9 +180,6 @@ EZOut ships with a rich PSModuleInfo formatter, which will display the module na
 ~~~PowerShell
 Get-Module EZOut | Format-Custom
 ~~~
-
-
-
 
 
 


### PR DESCRIPTION
## 1.8.8.1:
* Format-YAML now supports -Indent (Fixes #59)
* Format-YAML now supports all primitive types (Fixes #58). Thanks @dfinke!
---