### PR TITLE
Format-Markdown-Fix

### DIFF
--- a/.github/workflows/TestReleaseAndPublish.yml
+++ b/.github/workflows/TestReleaseAndPublish.yml
@@ -422,16 +422,27 @@ jobs:
           $ModulePath,
           
           [string[]]
-          $Exclude = @('*.png', '*.mp4', '*.jpg','*.jpeg')
+          $Exclude = @('*.png', '*.mp4', '*.jpg','*.jpeg', '*.gif', 'docs[/\]*')
           )
+          
           $gitHubEvent = if ($env:GITHUB_EVENT_PATH) {
               [IO.File]::ReadAllText($env:GITHUB_EVENT_PATH) | ConvertFrom-Json
           } else { $null }
+          
+          if (-not $Exclude) {
+              $Exclude = @('*.png', '*.mp4', '*.jpg','*.jpeg', '*.gif','docs[/\]*')
+          }
           
           
           @"
           ::group::GitHubEvent
           $($gitHubEvent | ConvertTo-Json -Depth 100)
+          ::endgroup::
+          "@ | Out-Host
+          
+          @"
+          ::group::PSBoundParameters
+          $($PSBoundParameters | ConvertTo-Json -Depth 100)
           ::endgroup::
           "@ | Out-Host
           
@@ -479,11 +490,12 @@ jobs:
               }
           
               if ($Exclude) {
+                  "::notice::Attempting to Exlcude $exclude" | Out-Host
                   Get-ChildItem $moduleTempPath -Recurse |
-                      Where-Object {
+                      Where-Object {                
                           foreach ($ex in $exclude) {
                               if ($_.FullName -like $ex) {
-                                  "::notice::Excluding $($_.FullName)"
+                                  "::notice::Excluding $($_.FullName)" | Out-Host
                                   return $true
                               }
                           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.9.2:
+* Format-Markdown:
+  * Improving Handling of | (Fixes #71)
+  * Not escaping code blocks (undoes #69)
+* No longer including images with PowerShell Gallery package (Fixes #67)
+---
+
 ## 1.9.1:
 * Format-Markdown:  Escaping -Code blocks (Fixes #69)
 ---

--- a/EZOut.format.ps1xml
+++ b/EZOut.format.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.9.1: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.9.2: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <SelectionSets>
     <SelectionSet>
@@ -1436,7 +1436,7 @@ if ($Request -or $Host.UI.SupportsHTML) {
                     [Environment]::newline + # then a newline,
                     $(
                         $codeContent = $(if ($ScriptBlock) { "$scriptBlock" } else { $inputObject | LinkInput})  # then the -ScriptBlock or -InputObject
-                        [Web.HttpUtility]::HtmlEncode($codeContent)
+                        $codeContent
                     ) +
                     [Environment]::newline + # then a newline
                 '```' # then close the code fence.
@@ -1544,7 +1544,7 @@ if ($Request -or $Host.UI.SupportsHTML) {
                             } else {
                                 $prop.Name
                             }
-                        }) -replace ([Environment]::newline), '&lt;br/&gt;' -replace '\|', '`|' -join '|') + '|'
+                        }) -replace ([Environment]::newline), '&lt;br/&gt;' -replace '\|', '\|' -join '|') + '|'
                     # Then create the alignment row.
                     $markdownLines +=
                         '|' + $(
@@ -1575,7 +1575,7 @@ if ($Request -or $Host.UI.SupportsHTML) {
                                     
                                     $columnNumber++
                                 }
-                            ) -replace ([Environment]::newline), '&lt;br/&gt;' -replace '\|', '`|' -join '|') + '|'                    
+                            ) -replace ([Environment]::newline), '&lt;br/&gt;' -replace '\|', '\|' -join '|') + '|'                    
                     $IsFirst = $false
                 }
                 
@@ -1590,7 +1590,7 @@ if ($Request -or $Host.UI.SupportsHTML) {
                                 $prop.Value | LinkInput
                             }
                         }
-                    ) -replace ([Environment]::newline), '&lt;br/&gt;' -replace '\|', '`|' -join '|') + '|'
+                    ) -replace ([Environment]::newline), '&lt;br/&gt;' -replace '\|', '\|' -join '|') + '|'
 
                 $markdownLines += $markdownLine
             }                                    
@@ -1623,7 +1623,7 @@ if ($Request -or $Host.UI.SupportsHTML) {
             foreach ($ml in $markdownLines) {
                 if ($ml -match '\^|') {
                     $columnCount = 0
-                    foreach ($tablePart in $ml -split '\|' -ne '') {
+                    foreach ($tablePart in $ml -split '(?&lt;!\\)\|' -ne '') {
                         if ((-not $maxColumnSize[$columnCount]) -or $maxColumnSize[$columnCount] -lt $tablePart.Length) {
                             $maxColumnSize[$columnCount] = [Math]::Max($tablePart.Length, 2)
                         }
@@ -1636,7 +1636,7 @@ if ($Request -or $Host.UI.SupportsHTML) {
                 if ($ml -match '\^|') {
                     $columnCount = 0
                     # Recreate the line with the right amount of padding.
-                    '|' + (@(foreach ($tablePart in $ml -split '\|' -ne '') {
+                    '|' + (@(foreach ($tablePart in $ml -split '(?&lt;!\\)\|' -ne '') {
                         if ($tablePart -match '^[:\-]+$') {
                             if ($tablePart -match '^\:-{0,}\:$') { # If it's an alignment column, make sure to keep the alignment.
                                 if ($maxColumnSize[$columnCount] -gt 2) {

--- a/EZOut.psd1
+++ b/EZOut.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     ModuleToProcess = 'EZOut.psm1'
-    ModuleVersion = '1.9.1'
+    ModuleVersion = '1.9.2'
     GUID = 'cef786f0-8a0b-4a5d-a2c6-b433095354cd'
     Author = 'James Brundage'
     CompanyName = 'Start-Automating'
@@ -43,6 +43,12 @@
 
             Tags = '.ps1xml', 'Format','Output','Types', 'Colorized'
             ReleaseNotes = @'
+## 1.9.2:
+* Format-Markdown:
+  * Improving Handling of | (Fixes #71)
+  * Not escaping code blocks (undoes #69)
+* No longer including images with PowerShell Gallery package (Fixes #67)
+---
 ## 1.9.1:
 * Format-Markdown:  Escaping -Code blocks (Fixes #69)
 ---

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -1174,11 +1174,7 @@ describe 'Format-Markdown' {
         $formatMarkdown = @{a='b'} | Format-Markdown
         $formatMarkdown | Should -belike '*|a*'
         $formatMarkdown | Should -belike '*|b*'
-    }
-
-    it 'Will escape code within -Code blocks' {
-        { =<svg> } | Format-Markdown | Should -BeLike '*&lt;svg&gt;*'
-    }    
+    }        
 }
 
 describe 'Format-Hashtable' {

--- a/Format-Markdown.ps1
+++ b/Format-Markdown.ps1
@@ -291,7 +291,7 @@ function Format-Markdown
                             } else {
                                 $prop.Name
                             }
-                        }) -replace ([Environment]::newline), '<br/>' -replace '\|', '`|' -join '|') + '|'
+                        }) -replace ([Environment]::newline), '<br/>' -replace '\|', '\|' -join '|') + '|'
                     # Then create the alignment row.
                     $markdownLines +=
                         '|' + $(
@@ -322,7 +322,7 @@ function Format-Markdown
                                     
                                     $columnNumber++
                                 }
-                            ) -replace ([Environment]::newline), '<br/>' -replace '\|', '`|' -join '|') + '|'                    
+                            ) -replace ([Environment]::newline), '<br/>' -replace '\|', '\|' -join '|') + '|'                    
                     $IsFirst = $false
                 }
                 
@@ -337,7 +337,7 @@ function Format-Markdown
                                 $prop.Value | LinkInput
                             }
                         }
-                    ) -replace ([Environment]::newline), '<br/>' -replace '\|', '`|' -join '|') + '|'
+                    ) -replace ([Environment]::newline), '<br/>' -replace '\|', '\|' -join '|') + '|'
 
                 $markdownLines += $markdownLine
             }                                    
@@ -370,7 +370,7 @@ function Format-Markdown
             foreach ($ml in $markdownLines) {
                 if ($ml -match '\^|') {
                     $columnCount = 0
-                    foreach ($tablePart in $ml -split '\|' -ne '') {
+                    foreach ($tablePart in $ml -split '(?<!\\)\|' -ne '') {
                         if ((-not $maxColumnSize[$columnCount]) -or $maxColumnSize[$columnCount] -lt $tablePart.Length) {
                             $maxColumnSize[$columnCount] = [Math]::Max($tablePart.Length, 2)
                         }
@@ -383,7 +383,7 @@ function Format-Markdown
                 if ($ml -match '\^|') {
                     $columnCount = 0
                     # Recreate the line with the right amount of padding.
-                    '|' + (@(foreach ($tablePart in $ml -split '\|' -ne '') {
+                    '|' + (@(foreach ($tablePart in $ml -split '(?<!\\)\|' -ne '') {
                         if ($tablePart -match '^[:\-]+$') {
                             if ($tablePart -match '^\:-{0,}\:$') { # If it's an alignment column, make sure to keep the alignment.
                                 if ($maxColumnSize[$columnCount] -gt 2) {

--- a/Format-Markdown.ps1
+++ b/Format-Markdown.ps1
@@ -183,7 +183,7 @@ function Format-Markdown
                     [Environment]::newline + # then a newline,
                     $(
                         $codeContent = $(if ($ScriptBlock) { "$scriptBlock" } else { $inputObject | LinkInput})  # then the -ScriptBlock or -InputObject
-                        [Web.HttpUtility]::HtmlEncode($codeContent)
+                        $codeContent
                     ) +
                     [Environment]::newline + # then a newline
                 '```' # then close the code fence.

--- a/docs/Add-FormatData.md
+++ b/docs/Add-FormatData.md
@@ -31,8 +31,8 @@ temporary module to use the formatting file.
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
-# Let's start off by looking at how something like XML is rendered in PowerShell
-[xml]"<a an='anattribute'><b d='attribute'><c/></b></a>"
+# Let&#39;s start off by looking at how something like XML is rendered in PowerShell
+[xml]&quot;&lt;a an=&#39;anattribute&#39;&gt;&lt;b d=&#39;attribute&#39;&gt;&lt;c/&gt;&lt;/b&gt;&lt;/a&gt;&quot;
 ```
 # It's not very intuitive.
 # I cannot really only see the element I am looking at, instead of a chunk of data
@@ -126,7 +126,7 @@ System.Management.Automation.PSModuleInfo
 ---
 ### Syntax
 ```PowerShell
-Add-FormatData [-FormatXml] <XmlDocument> [[-Name] <String>] [-PassThru] [<CommonParameters>]
+Add-FormatData [-FormatXml] &lt;XmlDocument&gt; [[-Name] &lt;String&gt;] [-PassThru] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Add-TypeData.md
+++ b/docs/Add-TypeData.md
@@ -89,7 +89,7 @@ System.Management.Automation.PSModuleInfo
 ---
 ### Syntax
 ```PowerShell
-Add-TypeData [-TypeXml] <XmlDocument> [[-Name] <String>] [-PassThru] [<CommonParameters>]
+Add-TypeData [-TypeXml] &lt;XmlDocument&gt; [[-Name] &lt;String&gt;] [-PassThru] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.9.2:
+* Format-Markdown:
+  * Improving Handling of | (Fixes #71)
+  * Not escaping code blocks (undoes #69)
+* No longer including images with PowerShell Gallery package (Fixes #67)
+---
+
 ## 1.9.1:
 * Format-Markdown:  Escaping -Code blocks (Fixes #69)
 ---

--- a/docs/Clear-FormatData.md
+++ b/docs/Clear-FormatData.md
@@ -35,7 +35,7 @@ System.Nullable
 ---
 ### Syntax
 ```PowerShell
-Clear-FormatData [<CommonParameters>]
+Clear-FormatData [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Clear-TypeData.md
+++ b/docs/Clear-TypeData.md
@@ -23,7 +23,7 @@ The formatting data must have been added with Add-FormatData
 ---
 ### Syntax
 ```PowerShell
-Clear-TypeData [<CommonParameters>]
+Clear-TypeData [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/ConvertTo-PropertySet.md
+++ b/docs/ConvertTo-PropertySet.md
@@ -75,7 +75,7 @@ System.String
 ---
 ### Syntax
 ```PowerShell
-ConvertTo-PropertySet -SelectedObject <Object> [-Name] <Object> [<CommonParameters>]
+ConvertTo-PropertySet -SelectedObject &lt;Object&gt; [-Name] &lt;Object&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Find-FormatView.md
+++ b/docs/Find-FormatView.md
@@ -43,7 +43,7 @@ The name of the type of format view to find
 ---
 ### Syntax
 ```PowerShell
-Find-FormatView [-TypeName] <String> [<CommonParameters>]
+Find-FormatView [-TypeName] &lt;String&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Format-Hashtable.md
+++ b/docs/Format-Hashtable.md
@@ -22,7 +22,7 @@ Handles nested hashtables and indents nested hashtables automatically.
 #### EXAMPLE 1
 ```PowerShell
 # Corrects the presentation of a PowerShell hashtable
-[Ordered]@{Foo='Bar';Baz='Bing';Boo=@{Bam='Blang'}} | Format-Hashtable
+[Ordered]@{Foo=&#39;Bar&#39;;Baz=&#39;Bing&#39;;Boo=@{Bam=&#39;Blang&#39;}} | Format-Hashtable
 ```
 
 ---
@@ -175,7 +175,7 @@ Beneath this depth, items will simply be returned as $null.
 ---
 ### Syntax
 ```PowerShell
-Format-Hashtable [[-InputObject] <PSObject>] [-AsScriptBlock] [-AsPSObject] [-Sort] [-ExpandCredential] [-Compress] [-Safe] [-Depth <Int32>] [<CommonParameters>]
+Format-Hashtable [[-InputObject] &lt;PSObject&gt;] [-AsScriptBlock] [-AsPSObject] [-Sort] [-ExpandCredential] [-Compress] [-Safe] [-Depth &lt;Int32&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Format-Heatmap.md
+++ b/docs/Format-Heatmap.md
@@ -119,7 +119,7 @@ To pass a Hex color as an int, simply replace # with 0x
 ---
 ### Syntax
 ```PowerShell
-Format-Heatmap [[-InputObject] <Object>] [-HeatMapMax] <Object> [[-HeatMapMiddle] <Object>] [[-HeatMapMin] <Object>] [[-HeatMapCool] <Int32>] [[-HeatMapHot] <Int32>] [<CommonParameters>]
+Format-Heatmap [[-InputObject] &lt;Object&gt;] [-HeatMapMax] &lt;Object&gt; [[-HeatMapMiddle] &lt;Object&gt;] [[-HeatMapMin] &lt;Object&gt;] [[-HeatMapCool] &lt;Int32&gt;] [[-HeatMapHot] &lt;Int32&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Format-Markdown.md
+++ b/docs/Format-Markdown.md
@@ -382,7 +382,7 @@ If provided, will output a script block as a Markdown code block.
 ---
 ### Syntax
 ```PowerShell
-Format-Markdown [[-InputObject] <PSObject>] [-MarkdownParagraph] [-MarkdownTable] [[-MarkdownTableAlignment] <String[]>] [[-Property] <PSObject[]>] [[-Heading] <String>] [[-HeadingSize] <Int32>] [[-Link] <String>] [[-ImageLink] <String>] [-BulletPoint] [-Checkbox] [-Checked] [-NumberedList] [-BlockQuote] [[-BlockQuoteDepth] <Int32>] [[-Number] <Int32>] [-HorizontalRule] [-Code] [[-CodeLanguage] <String>] [[-ScriptBlock] <ScriptBlock>] [<CommonParameters>]
+Format-Markdown [[-InputObject] &lt;PSObject&gt;] [-MarkdownParagraph] [-MarkdownTable] [[-MarkdownTableAlignment] &lt;String[]&gt;] [[-Property] &lt;PSObject[]&gt;] [[-Heading] &lt;String&gt;] [[-HeadingSize] &lt;Int32&gt;] [[-Link] &lt;String&gt;] [[-ImageLink] &lt;String&gt;] [-BulletPoint] [-Checkbox] [-Checked] [-NumberedList] [-BlockQuote] [[-BlockQuoteDepth] &lt;Int32&gt;] [[-Number] &lt;Int32&gt;] [-HorizontalRule] [-Code] [[-CodeLanguage] &lt;String&gt;] [[-ScriptBlock] &lt;ScriptBlock&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Format-Object.md
+++ b/docs/Format-Object.md
@@ -35,7 +35,7 @@ Formats any object, using any number of Format-Object extensions.
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
-"red" | Format-Object -ForegroundColor "red"
+&quot;red&quot; | Format-Object -ForegroundColor &quot;red&quot;
 ```
 
 #### EXAMPLE 2
@@ -60,7 +60,7 @@ Formats any object, using any number of Format-Object extensions.
 ---
 ### Syntax
 ```PowerShell
-Format-Object [[-InputObject] <PSObject>] [<CommonParameters>]
+Format-Object [[-InputObject] &lt;PSObject&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Format-RichText.md
+++ b/docs/Format-RichText.md
@@ -171,7 +171,7 @@ If set, will not clear formatting
 ---
 ### Syntax
 ```PowerShell
-Format-RichText [[-InputObject] <PSObject>] [[-ForegroundColor] <String>] [[-BackgroundColor] <String>] [-Bold] [-Blink] [-Strikethru] [-Underline] [-Invert] [-NoClear] [<CommonParameters>]
+Format-RichText [[-InputObject] &lt;PSObject&gt;] [[-ForegroundColor] &lt;String&gt;] [[-BackgroundColor] &lt;String&gt;] [-Bold] [-Blink] [-Strikethru] [-Underline] [-Invert] [-NoClear] [&lt;CommonParameters&gt;]
 ```
 ---
 ### Notes

--- a/docs/Format-YAML.md
+++ b/docs/Format-YAML.md
@@ -13,12 +13,12 @@ Formats an object as YAML.
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
-Format-Yaml -InputObject @("a", "b", "c")
+Format-Yaml -InputObject @(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;)
 ```
 
 #### EXAMPLE 2
 ```PowerShell
-@{a="b";c="d";e=@{f=@('g')}} | Format-Yaml
+@{a=&quot;b&quot;;c=&quot;d&quot;;e=@{f=@(&#39;g&#39;)}} | Format-Yaml
 ```
 
 ---
@@ -90,7 +90,7 @@ Beyond this depth, an empty string will be returned.
 ---
 ### Syntax
 ```PowerShell
-Format-YAML [[-InputObject] <PSObject>] [-YamlHeader] [[-Indent] <Int32>] [[-Depth] <Int32>] [<CommonParameters>]
+Format-YAML [[-InputObject] &lt;PSObject&gt;] [-YamlHeader] [[-Indent] &lt;Int32&gt;] [[-Depth] &lt;Int32&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Get-EZOutExtension.md
+++ b/docs/Get-EZOutExtension.md
@@ -412,7 +412,7 @@ Extension
 ---
 ### Syntax
 ```PowerShell
-Get-EZOutExtension [[-ExtensionPath] <String>] [-Force] [[-CommandName] <String[]>] [[-ExtensionName] <String[]>] [-Like] [-Match] [-DynamicParameter] [-CouldRun] [-Run] [-Stream] [[-DynamicParameterSetName] <String>] [[-DynamicParameterPositionOffset] <Int32>] [-NoMandatoryDynamicParameter] [[-ValidateInput] <PSObject>] [-AllValid] [[-ParameterSetName] <String>] [[-Parameter] <IDictionary>] [-SteppablePipeline] [-Help] [[-ParameterHelp] <String[]>] [-Example] [-FullHelp] [<CommonParameters>]
+Get-EZOutExtension [[-ExtensionPath] &lt;String&gt;] [-Force] [[-CommandName] &lt;String[]&gt;] [[-ExtensionName] &lt;String[]&gt;] [-Like] [-Match] [-DynamicParameter] [-CouldRun] [-Run] [-Stream] [[-DynamicParameterSetName] &lt;String&gt;] [[-DynamicParameterPositionOffset] &lt;Int32&gt;] [-NoMandatoryDynamicParameter] [[-ValidateInput] &lt;PSObject&gt;] [-AllValid] [[-ParameterSetName] &lt;String&gt;] [[-Parameter] &lt;IDictionary&gt;] [-SteppablePipeline] [-Help] [[-ParameterHelp] &lt;String[]&gt;] [-Example] [-FullHelp] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Get-FormatFile.md
+++ b/docs/Get-FormatFile.md
@@ -69,7 +69,7 @@ Get-FormatFile -OnlyBuildIn
 ---
 ### Syntax
 ```PowerShell
-Get-FormatFile [-OnlyFromModule] [-OnlyBuiltIn] [-FromSnapins] [<CommonParameters>]
+Get-FormatFile [-OnlyFromModule] [-OnlyBuiltIn] [-FromSnapins] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Get-PropertySet.md
+++ b/docs/Get-PropertySet.md
@@ -47,7 +47,7 @@ System.Management.Automation.PSObject
 ---
 ### Syntax
 ```PowerShell
-Get-PropertySet [[-TypeName] <String[]>] [<CommonParameters>]
+Get-PropertySet [[-TypeName] &lt;String[]&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Import-FormatView.md
+++ b/docs/Import-FormatView.md
@@ -32,7 +32,7 @@ Imports a Format View defined in .format or .view .ps1 files
 ---
 ### Syntax
 ```PowerShell
-Import-FormatView [-FilePath] <String[]> [<CommonParameters>]
+Import-FormatView [-FilePath] &lt;String[]&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Import-TypeView.md
+++ b/docs/Import-TypeView.md
@@ -56,7 +56,7 @@ If set, will generate an identical typeview for the deserialized form of each ty
 ---
 ### Syntax
 ```PowerShell
-Import-TypeView [-FilePath] <String[]> [-Deserialized] [<CommonParameters>]
+Import-TypeView [-FilePath] &lt;String[]&gt; [-Deserialized] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Out-FormatData.md
+++ b/docs/Out-FormatData.md
@@ -16,12 +16,12 @@ A Detailed Description of what the command does
 # Create a quick view for any XML element.
 # Piping it into Out-FormatData will make one or more format views into a full format XML file
 # Piping the output of that into Add-FormatData will create a temporary module to hold the formatting data
-# There's also a Remove-FormatData and
-Write-FormatView -TypeName "System.Xml.XmlNode" -Wrap -Property "Xml" -VirtualProperty @{
-    "Xml" = {
+# There&#39;s also a Remove-FormatData and
+Write-FormatView -TypeName &quot;System.Xml.XmlNode&quot; -Wrap -Property &quot;Xml&quot; -VirtualProperty @{
+    &quot;Xml&quot; = {
         $strWrite = New-Object IO.StringWriter
         ([xml]$_.Outerxml).Save($strWrite)
-        "$strWrite"
+        &quot;$strWrite&quot;
     }
 } |
     Out-FormatData
@@ -73,7 +73,7 @@ System.String
 ---
 ### Syntax
 ```PowerShell
-Out-FormatData [-FormatXml] <XmlDocument> [[-ModuleName] <String>] [<CommonParameters>]
+Out-FormatData [-FormatXml] &lt;XmlDocument&gt; [[-ModuleName] &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Out-TypeData.md
+++ b/docs/Out-TypeData.md
@@ -16,12 +16,12 @@ Takes a series of type views and format actions and outputs a type data XML
 # Create a quick view for any XML element.
 # Piping it into Out-FormatData will make one or more format views into a full format XML file
 # Piping the output of that into Add-FormatData will create a temporary module to hold the formatting data
-# There's also a Remove-FormatData and
-Write-FormatView -TypeName "System.Xml.XmlNode" -Wrap -Property "Xml" -VirtualProperty @{
-    "Xml" = {
+# There&#39;s also a Remove-FormatData and
+Write-FormatView -TypeName &quot;System.Xml.XmlNode&quot; -Wrap -Property &quot;Xml&quot; -VirtualProperty @{
+    &quot;Xml&quot; = {
         $strWrite = New-Object IO.StringWriter
         ([xml]$_.Outerxml).Save($strWrite)
-        "$strWrite"
+        &quot;$strWrite&quot;
     }
 } |
     Out-FormatData
@@ -49,7 +49,7 @@ but it's easier to use Write-FormatView to create it
 ---
 ### Syntax
 ```PowerShell
-Out-TypeData [-TypeXml] <XmlDocument> [<CommonParameters>]
+Out-TypeData [-TypeXml] &lt;XmlDocument&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -188,4 +188,3 @@ Get-Module EZOut | Format-Custom
 
 
 
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -188,3 +188,4 @@ Get-Module EZOut | Format-Custom
 
 
 
+

--- a/docs/Remove-FormatData.md
+++ b/docs/Remove-FormatData.md
@@ -31,7 +31,7 @@ this is the name of the module.
 ---
 ### Syntax
 ```PowerShell
-Remove-FormatData -ModuleName <String> [<CommonParameters>]
+Remove-FormatData -ModuleName &lt;String&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Remove-TypeData.md
+++ b/docs/Remove-TypeData.md
@@ -31,7 +31,7 @@ this is the name of the module.
 ---
 ### Syntax
 ```PowerShell
-Remove-TypeData -ModuleName <String> [<CommonParameters>]
+Remove-TypeData -ModuleName &lt;String&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 Remove-TypeData

--- a/docs/Write-EZFormatFile.md
+++ b/docs/Write-EZFormatFile.md
@@ -98,7 +98,7 @@ The destination path.  By default, the script's root.
 ---
 ### Syntax
 ```PowerShell
-Write-EZFormatFile [[-Format] <ScriptBlock[]>] [[-Type] <ScriptBlock[]>] [[-ModuleName] <String>] [[-SourcePath] <String>] [[-DestinationPath] <String>] [<CommonParameters>]
+Write-EZFormatFile [[-Format] &lt;ScriptBlock[]&gt;] [[-Type] &lt;ScriptBlock[]&gt;] [[-ModuleName] &lt;String&gt;] [[-SourcePath] &lt;String&gt;] [[-DestinationPath] &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-FormatControl.md
+++ b/docs/Write-FormatControl.md
@@ -64,7 +64,7 @@ code in between Write-FormatViewExpression will not be included in the formatter
 ---
 ### Syntax
 ```PowerShell
-Write-FormatControl [-Name] <String> [-Action] <ScriptBlock> [<CommonParameters>]
+Write-FormatControl [-Name] &lt;String&gt; [-Action] &lt;ScriptBlock&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-FormatCustomView.md
+++ b/docs/Write-FormatCustomView.md
@@ -27,7 +27,7 @@ Writes the .format.ps1xml fragement for a custom control view, or a custom contr
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
-Write-FormatCustomView -Action {  "This is a message from Process $pid" }
+Write-FormatCustomView -Action {  &quot;This is a message from Process $pid&quot; }
 ```
 
 ---
@@ -177,7 +177,7 @@ At least one view must have no conditions.
 ---
 ### Syntax
 ```PowerShell
-Write-FormatCustomView [-Action] <ScriptBlock[]> [[-Indent] <Int32>] [-AsControl] [[-Name] <String>] [[-VisibilityCondition] <ScriptBlock[]>] [[-ViewTypeName] <String>] [[-ViewSelectionSet] <String>] [[-ViewCondition] <ScriptBlock>] [<CommonParameters>]
+Write-FormatCustomView [-Action] &lt;ScriptBlock[]&gt; [[-Indent] &lt;Int32&gt;] [-AsControl] [[-Name] &lt;String&gt;] [[-VisibilityCondition] &lt;ScriptBlock[]&gt;] [[-ViewTypeName] &lt;String&gt;] [[-ViewSelectionSet] &lt;String&gt;] [[-ViewCondition] &lt;ScriptBlock&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-FormatListView.md
+++ b/docs/Write-FormatListView.md
@@ -187,7 +187,7 @@ and at least one of these views must not havea condition.
 ---
 ### Syntax
 ```PowerShell
-Write-FormatListView -Property <String[]> [-AliasProperty <IDictionary>] [-VirtualProperty <IDictionary>] [[-FormatProperty] <IDictionary>] [-ColorProperty <IDictionary>] [-ConditionalProperty <IDictionary>] [-ViewTypeName <String>] [-ViewSelectionSet <String>] [-ViewCondition <ScriptBlock>] [<CommonParameters>]
+Write-FormatListView -Property &lt;String[]&gt; [-AliasProperty &lt;IDictionary&gt;] [-VirtualProperty &lt;IDictionary&gt;] [[-FormatProperty] &lt;IDictionary&gt;] [-ColorProperty &lt;IDictionary&gt;] [-ConditionalProperty &lt;IDictionary&gt;] [-ViewTypeName &lt;String&gt;] [-ViewSelectionSet &lt;String&gt;] [-ViewCondition &lt;ScriptBlock&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-FormatTableView.md
+++ b/docs/Write-FormatTableView.md
@@ -24,8 +24,8 @@ Write-FormatTableView -Property myFirstProperty,mySecondProperty -TypeName MyPro
 
 #### EXAMPLE 2
 ```PowerShell
-Write-FormatTableView -Property "Friendly Property Name" -RenameProperty @{
-    "Friendly Property Name" = 'SystemName'
+Write-FormatTableView -Property &quot;Friendly Property Name&quot; -RenameProperty @{
+    &quot;Friendly Property Name&quot; = &#39;SystemName&#39;
 }
 ```
 
@@ -36,11 +36,11 @@ Write-FormatTableView -Property Name, Bio -Width 20 -Wrap
 
 #### EXAMPLE 4
 ```PowerShell
-Write-FormatTableView -Property Number, IsEven, IsOdd -AutoSize -ColorRow {if ($_.N % 2) { "#ff0000"} else {"#0f0"} } -VirtualProperty @{
+Write-FormatTableView -Property Number, IsEven, IsOdd -AutoSize -ColorRow {if ($_.N % 2) { &quot;#ff0000&quot;} else {&quot;#0f0&quot;} } -VirtualProperty @{
     IsEven = { -not ($_.N % 2)}
     IsOdd = { ($_.N % 2) -as [bool] }
 } -AliasProperty @{
-    Number = 'N'
+    Number = &#39;N&#39;
 }
 ```
 
@@ -301,7 +301,7 @@ System.String
 ---
 ### Syntax
 ```PowerShell
-Write-FormatTableView [-Property] <String[]> [-AliasProperty <IDictionary>] [-VirtualProperty <IDictionary>] [[-FormatProperty] <IDictionary>] [-AlignProperty <IDictionary>] [-ColorProperty <IDictionary>] [-ColorRow <ScriptBlock>] [-AutoSize] [-HideHeader] [-Width <Int32[]>] [-Wrap] [-ViewTypeName <String>] [-ViewSelectionSet <String>] [-ViewCondition <ScriptBlock>] [<CommonParameters>]
+Write-FormatTableView [-Property] &lt;String[]&gt; [-AliasProperty &lt;IDictionary&gt;] [-VirtualProperty &lt;IDictionary&gt;] [[-FormatProperty] &lt;IDictionary&gt;] [-AlignProperty &lt;IDictionary&gt;] [-ColorProperty &lt;IDictionary&gt;] [-ColorRow &lt;ScriptBlock&gt;] [-AutoSize] [-HideHeader] [-Width &lt;Int32[]&gt;] [-Wrap] [-ViewTypeName &lt;String&gt;] [-ViewSelectionSet &lt;String&gt;] [-ViewCondition &lt;ScriptBlock&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-FormatTreeView.md
+++ b/docs/Write-FormatTreeView.md
@@ -34,10 +34,10 @@ Write-FormatTreeView -TypeName System.IO.FileInfo, System.IO.DirectoryInfo -Node
     $_.EnumerateFiles()
 }, {
     foreach ($d in $_.EnumerateDirectories()) {
-        if ($d.Attributes -band 'Hidden') { continue }
+        if ($d.Attributes -band &#39;Hidden&#39;) { continue }
         $d
     }
-} -Branch ('' + [char]9500 + [char]9472 + [char]9472) -Trunk '|  ' |
+} -Branch (&#39;&#39; + [char]9500 + [char]9472 + [char]9472) -Trunk &#39;|  &#39; |
     Out-FormatData |
     Add-FormatData
 ```
@@ -312,7 +312,7 @@ This control must exist in the same format file.
 ---
 ### Syntax
 ```PowerShell
-Write-FormatTreeView [[-Property] <PSObject[]>] [[-Separator] <String>] [[-Branch] <String>] [[-Trunk] <String>] [[-TypeName] <String[]>] [[-SelectionSet] <String>] [[-ControlName] <String>] [[-ViewTypeName] <String>] [[-ViewSelectionSet] <String>] [[-ViewCondition] <ScriptBlock>] [[-EndBranch] <String>] [[-EndBranchScript] <ScriptBlock>] [[-HasChildren] <ScriptBlock[]>] [[-Children] <ScriptBlock[]>] [[-ChildNodeControl] <String[]>] [<CommonParameters>]
+Write-FormatTreeView [[-Property] &lt;PSObject[]&gt;] [[-Separator] &lt;String&gt;] [[-Branch] &lt;String&gt;] [[-Trunk] &lt;String&gt;] [[-TypeName] &lt;String[]&gt;] [[-SelectionSet] &lt;String&gt;] [[-ControlName] &lt;String&gt;] [[-ViewTypeName] &lt;String&gt;] [[-ViewSelectionSet] &lt;String&gt;] [[-ViewCondition] &lt;ScriptBlock&gt;] [[-EndBranch] &lt;String&gt;] [[-EndBranchScript] &lt;ScriptBlock&gt;] [[-HasChildren] &lt;ScriptBlock[]&gt;] [[-Children] &lt;ScriptBlock[]&gt;] [[-ChildNodeControl] &lt;String[]&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-FormatView.md
+++ b/docs/Write-FormatView.md
@@ -52,11 +52,11 @@ Write-FormatView -TypeName MyType -Property Property1, Property2
 
 #### EXAMPLE 2
 ```PowerShell
-Write-FormatView -TypeName ColorizedRow -Property Number, IsEven, IsOdd -AutoSize -ColorRow {if ($_.N % 2) { "#ff0000"} else {"#0f0"} } -VirtualProperty @{
+Write-FormatView -TypeName ColorizedRow -Property Number, IsEven, IsOdd -AutoSize -ColorRow {if ($_.N % 2) { &quot;#ff0000&quot;} else {&quot;#0f0&quot;} } -VirtualProperty @{
     IsEven = { -not ($_.N % 2)}
     IsOdd = { ($_.N % 2) -as [bool] }
 } -AliasProperty @{
-    Number = 'N'
+    Number = &#39;N&#39;
 } | 
     Out-FormatData | 
     Add-FormatData
@@ -70,11 +70,11 @@ foreach ($n in 1..5) {
 }
 #### EXAMPLE 3
 ```PowerShell
-Write-FormatView -TypeName "System.Xml.XmlNode" -Wrap -Property "Xml" -VirtualProperty @{
-    "Xml" = {
+Write-FormatView -TypeName &quot;System.Xml.XmlNode&quot; -Wrap -Property &quot;Xml&quot; -VirtualProperty @{
+    &quot;Xml&quot; = {
         $strWrite = New-Object IO.StringWriter
         ([xml]$_.Outerxml).Save($strWrite)
-        "$strWrite"
+        &quot;$strWrite&quot;
     }
 } |
     Out-FormatData |
@@ -512,19 +512,19 @@ If the format view is going to be outputted as a control, it will require a name
 ---
 ### Syntax
 ```PowerShell
-Write-FormatView [-TypeName] <String[]> [-Property] <String[]> [[-AliasProperty] <Hashtable>] [[-VirtualProperty] <Hashtable>] [[-FormatProperty] <Hashtable>] [-AlignProperty <IDictionary>] [-ColorProperty <IDictionary>] [-ColorRow <ScriptBlock>] [-AutoSize] [-HideHeader] [-Width <Int32[]>] [-IsSelectionSet] [-Wrap] [-GroupByProperty <String>] [-GroupByScript <ScriptBlock>] [-GroupLabel <String>] [-GroupAction <String>] [-Name <String>] [<CommonParameters>]
+Write-FormatView [-TypeName] &lt;String[]&gt; [-Property] &lt;String[]&gt; [[-AliasProperty] &lt;Hashtable&gt;] [[-VirtualProperty] &lt;Hashtable&gt;] [[-FormatProperty] &lt;Hashtable&gt;] [-AlignProperty &lt;IDictionary&gt;] [-ColorProperty &lt;IDictionary&gt;] [-ColorRow &lt;ScriptBlock&gt;] [-AutoSize] [-HideHeader] [-Width &lt;Int32[]&gt;] [-IsSelectionSet] [-Wrap] [-GroupByProperty &lt;String&gt;] [-GroupByScript &lt;ScriptBlock&gt;] [-GroupLabel &lt;String&gt;] [-GroupAction &lt;String&gt;] [-Name &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatView [-TypeName] <String[]> [-Property] <String[]> [[-AliasProperty] <Hashtable>] [[-VirtualProperty] <Hashtable>] [[-FormatProperty] <Hashtable>] [-ColorProperty <IDictionary>] [-ColorRow <ScriptBlock>] -AsList [-ConditionalProperty <IDictionary>] [-IsSelectionSet] [-GroupByProperty <String>] [-GroupByScript <ScriptBlock>] [-GroupLabel <String>] [-GroupAction <String>] [-Name <String>] [<CommonParameters>]
+Write-FormatView [-TypeName] &lt;String[]&gt; [-Property] &lt;String[]&gt; [[-AliasProperty] &lt;Hashtable&gt;] [[-VirtualProperty] &lt;Hashtable&gt;] [[-FormatProperty] &lt;Hashtable&gt;] [-ColorProperty &lt;IDictionary&gt;] [-ColorRow &lt;ScriptBlock&gt;] -AsList [-ConditionalProperty &lt;IDictionary&gt;] [-IsSelectionSet] [-GroupByProperty &lt;String&gt;] [-GroupByScript &lt;ScriptBlock&gt;] [-GroupLabel &lt;String&gt;] [-GroupAction &lt;String&gt;] [-Name &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatView [-TypeName] <String[]> [-AutoSize] [-IsSelectionSet] [-GroupByProperty <String>] [-GroupByScript <ScriptBlock>] [-GroupLabel <String>] [-GroupAction <String>] [-Name <String>] [<CommonParameters>]
+Write-FormatView [-TypeName] &lt;String[]&gt; [-AutoSize] [-IsSelectionSet] [-GroupByProperty &lt;String&gt;] [-GroupByScript &lt;ScriptBlock&gt;] [-GroupLabel &lt;String&gt;] [-GroupAction &lt;String&gt;] [-Name &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatView [-TypeName] <String[]> -Action <ScriptBlock[]> [-Indent <Int32>] [-IsSelectionSet] [-GroupByProperty <String>] [-GroupByScript <ScriptBlock>] [-GroupLabel <String>] [-GroupAction <String>] [-AsControl] [-Name <String>] [<CommonParameters>]
+Write-FormatView [-TypeName] &lt;String[]&gt; -Action &lt;ScriptBlock[]&gt; [-Indent &lt;Int32&gt;] [-IsSelectionSet] [-GroupByProperty &lt;String&gt;] [-GroupByScript &lt;ScriptBlock&gt;] [-GroupLabel &lt;String&gt;] [-GroupAction &lt;String&gt;] [-AsControl] [-Name &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatView [-TypeName] <String[]> -FormatXML <XmlDocument> [-IsSelectionSet] [-GroupByProperty <String>] [-GroupByScript <ScriptBlock>] [-GroupLabel <String>] [-GroupAction <String>] [-Name <String>] [<CommonParameters>]
+Write-FormatView [-TypeName] &lt;String[]&gt; -FormatXML &lt;XmlDocument&gt; [-IsSelectionSet] [-GroupByProperty &lt;String&gt;] [-GroupByScript &lt;ScriptBlock&gt;] [-GroupLabel &lt;String&gt;] [-GroupAction &lt;String&gt;] [-Name &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-FormatViewExpression.md
+++ b/docs/Write-FormatViewExpression.md
@@ -15,30 +15,30 @@ Expressions are used by custom format views and controls to conditionally displa
 #### EXAMPLE 1
 ```PowerShell
 Write-FormatViewExpression -ScriptBlock {
-    "hello world"
+    &quot;hello world&quot;
 }
 ```
 
 #### EXAMPLE 2
 ```PowerShell
-Write-FormatViewExpression -If { $_.Complete } -ScriptBlock { "Complete" }
+Write-FormatViewExpression -If { $_.Complete } -ScriptBlock { &quot;Complete&quot; }
 ```
 
 #### EXAMPLE 3
 ```PowerShell
-Write-FormatViewExpression -Text 'Hello World'
+Write-FormatViewExpression -Text &#39;Hello World&#39;
 ```
 
 #### EXAMPLE 4
 ```PowerShell
-# This will render the property 'Name' property of the underlying object
+# This will render the property &#39;Name&#39; property of the underlying object
 Write-FormatViewExpression -Property Name
 ```
 
 #### EXAMPLE 5
 ```PowerShell
-# This will render the property 'Status' of the current object,
-# if the current object's 'Complete' property is $false.
+# This will render the property &#39;Status&#39; of the current object,
+# if the current object&#39;s &#39;Complete&#39; property is $false.
 Write-FormatViewExpression -Property Status -If { -not $_.Complete }
 ```
 
@@ -359,19 +359,19 @@ System.String
 ---
 ### Syntax
 ```PowerShell
-Write-FormatViewExpression [-ControlName <String>] [-ScriptBlock] <ScriptBlock> [-If <ScriptBlock>] [-Bold] [-Underline] [-Invert] [-FormatString <String>] [-Enumerate] [-ForegroundColor <String>] [-BackgroundColor <String>] [-Count <UInt32>] [<CommonParameters>]
+Write-FormatViewExpression [-ControlName &lt;String&gt;] [-ScriptBlock] &lt;ScriptBlock&gt; [-If &lt;ScriptBlock&gt;] [-Bold] [-Underline] [-Invert] [-FormatString &lt;String&gt;] [-Enumerate] [-ForegroundColor &lt;String&gt;] [-BackgroundColor &lt;String&gt;] [-Count &lt;UInt32&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatViewExpression [-ControlName <String>] [-Property] <String> [-If <ScriptBlock>] [-Bold] [-Underline] [-Invert] [-FormatString <String>] [-Enumerate] [-ForegroundColor <String>] [-BackgroundColor <String>] [-Count <UInt32>] [<CommonParameters>]
+Write-FormatViewExpression [-ControlName &lt;String&gt;] [-Property] &lt;String&gt; [-If &lt;ScriptBlock&gt;] [-Bold] [-Underline] [-Invert] [-FormatString &lt;String&gt;] [-Enumerate] [-ForegroundColor &lt;String&gt;] [-BackgroundColor &lt;String&gt;] [-Count &lt;UInt32&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatViewExpression [-ControlName <String>] [-If <ScriptBlock>] -Text <String> [-Bold] [-Underline] [-Invert] [-FormatString <String>] [-Enumerate] [-ForegroundColor <String>] [-BackgroundColor <String>] [-Count <UInt32>] [<CommonParameters>]
+Write-FormatViewExpression [-ControlName &lt;String&gt;] [-If &lt;ScriptBlock&gt;] -Text &lt;String&gt; [-Bold] [-Underline] [-Invert] [-FormatString &lt;String&gt;] [-Enumerate] [-ForegroundColor &lt;String&gt;] [-BackgroundColor &lt;String&gt;] [-Count &lt;UInt32&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatViewExpression [-ControlName <String>] [-If <ScriptBlock>] -AssemblyName <String> -BaseName <String> -ResourceID <String> [-Bold] [-Underline] [-Invert] [-FormatString <String>] [-Enumerate] [-ForegroundColor <String>] [-BackgroundColor <String>] [-Count <UInt32>] [<CommonParameters>]
+Write-FormatViewExpression [-ControlName &lt;String&gt;] [-If &lt;ScriptBlock&gt;] -AssemblyName &lt;String&gt; -BaseName &lt;String&gt; -ResourceID &lt;String&gt; [-Bold] [-Underline] [-Invert] [-FormatString &lt;String&gt;] [-Enumerate] [-ForegroundColor &lt;String&gt;] [-BackgroundColor &lt;String&gt;] [-Count &lt;UInt32&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Write-FormatViewExpression [-ControlName <String>] [-If <ScriptBlock>] -Newline [-Bold] [-Underline] [-Invert] [-FormatString <String>] [-Enumerate] [-ForegroundColor <String>] [-BackgroundColor <String>] [-Count <UInt32>] [<CommonParameters>]
+Write-FormatViewExpression [-ControlName &lt;String&gt;] [-If &lt;ScriptBlock&gt;] -Newline [-Bold] [-Underline] [-Invert] [-FormatString &lt;String&gt;] [-Enumerate] [-ForegroundColor &lt;String&gt;] [-BackgroundColor &lt;String&gt;] [-Count &lt;UInt32&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-PropertySet.md
+++ b/docs/Write-PropertySet.md
@@ -101,7 +101,7 @@ The names of the properties to include in the property set
 ---
 ### Syntax
 ```PowerShell
-Write-PropertySet [-TypeName] <String> [-Name] <String> [-PropertyName] <String[]> [<CommonParameters>]
+Write-PropertySet [-TypeName] &lt;String&gt; [-Name] &lt;String&gt; [-PropertyName] &lt;String[]&gt; [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Write-TypeView.md
+++ b/docs/Write-TypeView.md
@@ -289,7 +289,7 @@ System.String
 ---
 ### Syntax
 ```PowerShell
-Write-TypeView [-TypeName] <String[]> [-ScriptMethod <IDictionary>] [-ScriptProperty <IDictionary>] [-NoteProperty <IDictionary>] [-AliasProperty <IDictionary>] [-EventGenerator <IDictionary>] [-EventName <String[]>] [-DefaultDisplay <String[]>] [-IdProperty <String>] [-SerializationDepth <Int32>] [-Reserializer <Type>] [-PropertySet <IDictionary>] [-HideProperty <String[]>] [-Deserialized] [<CommonParameters>]
+Write-TypeView [-TypeName] &lt;String[]&gt; [-ScriptMethod &lt;IDictionary&gt;] [-ScriptProperty &lt;IDictionary&gt;] [-NoteProperty &lt;IDictionary&gt;] [-AliasProperty &lt;IDictionary&gt;] [-EventGenerator &lt;IDictionary&gt;] [-EventName &lt;String[]&gt;] [-DefaultDisplay &lt;String[]&gt;] [-IdProperty &lt;String&gt;] [-SerializationDepth &lt;Int32&gt;] [-Reserializer &lt;Type&gt;] [-PropertySet &lt;IDictionary&gt;] [-HideProperty &lt;String[]&gt;] [-Deserialized] [&lt;CommonParameters&gt;]
 ```
 ---
 


### PR DESCRIPTION
## 1.9.2:
* Format-Markdown:
  * Improving Handling of | (Fixes #71)
  * Not escaping code blocks (undoes #69)
* No longer including images with PowerShell Gallery package (Fixes #67)
---