### PR TITLE
EZOut 1.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.9.9:
+
+* Format-RichText -Hyperlink/-Link/-HRef now works (Fixes #93)
+* Format-RichText now supports -Alignment and -LineLength (Fixes #45)
+* GitHub Action no longer output extra information (Fixes #98)
+
+---
+
 ## 1.9.8:
 
 * Format-RichText now supports -Hyperlink (Fixes #93)

--- a/EZOut.GitHubAction.PSDevOps.ps1
+++ b/EZOut.GitHubAction.PSDevOps.ps1
@@ -1,22 +1,8 @@
 ﻿#requires -Module PSDevOps
 #requires -Module EZOut
 Import-BuildStep -ModuleName EZOut
-New-GitHubAction -Name "UseEZOut" -Description 'Generate Formatting and Types .ps1xml for PowerShell Modules, using EZOut' -Action EZOutAction -Icon code  -ActionOutput ([Ordered]@{
-    EZOutScriptRuntime = [Ordered]@{
-        description = "The time it took the .EZOutScript parameter to run"
-        value = '${{steps.EZOutAction.outputs.EZOutScriptRuntime}}'
-    }
-    EZOutPS1Runtime = [Ordered]@{
-        description = "The time it took all .EZOut.ps1 files to run"
-        value = '${{steps.EZOutAction.outputs.EZOutPS1Runtime}}'
-    }
-    EZOutPS1Files = [Ordered]@{
-        description = "The .EZOut.ps1 files that were run (separated by semicolons)"
-        value = '${{steps.EZOutAction.outputs.EZOutPS1Files}}'
-    }
-    EZOutPS1Count = [Ordered]@{
-        description = "The number of .EZOut.ps1 files that were run"
-        value = '${{steps.EZOutAction.outputs.EZOutPS1Count}}'
-    }
-}) |
-    Set-Content .\action.yml -Encoding UTF8 -PassThru
+Push-Location $PSScriptRoot
+New-GitHubAction -Name "UseEZOut" -Description @'
+Generate Formatting and Types .ps1xml for PowerShell Modules, using EZOut
+'@ -Action EZOutAction -Icon code -OutputPath .\action.yml
+Pop-Location

--- a/EZOut.format.ps1xml
+++ b/EZOut.format.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.9.8: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.9.9: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <SelectionSets>
     <SelectionSet>

--- a/EZOut.format.ps1xml
+++ b/EZOut.format.ps1xml
@@ -975,7 +975,7 @@ if ($Request -or $Host.UI.SupportsHTML) {
     .Notes
         Stylized Output works in two contexts at present:
         * Rich consoles (Windows Terminal, PowerShell.exe, Pwsh.exe) (when $host.UI.SupportsVirtualTerminal)
-        * Web pages (Based off the presence of a $Request variable, or when $host.UI.SupportsHTML (you must add this property to $host.UI))        
+        * Web pages (Based off the presence of a $Request variable, or when $host.UI.SupportsHTML (you must add this property to $host.UI))
     #&gt;
     [Management.Automation.Cmdlet("Format","Object")]
     [ValidateScript({
@@ -1032,7 +1032,16 @@ if ($Request -or $Host.UI.SupportsHTML) {
     $Link,
 
     # If set, will not clear formatting
-    [switch]$NoClear
+    [switch]$NoClear,
+
+    # The alignment.  Defaulting to Left.
+    # Setting an alignment will pad the remaining space on each line.
+    [ValidateSet('Left','Right','Center')]
+    [string]
+    $Alignment,
+
+    # The length of a line.  By default, the buffer width
+    [int]$LineLength = $($host.UI.RawUI.BufferSize.Width)
     )    
 
     begin {
@@ -1042,6 +1051,19 @@ if ($Request -or $Host.UI.SupportsHTML) {
             Output='';Error='BrightRed';Warning='BrightYellow';
             Verbose='BrightCyan';Debug='Yellow';Progress='Cyan';
             Success='BrightGreen';Failure='Red';Default=''}
+
+        $ansiCode = [Regex]::new(@'
+        (?&lt;ANSI_Code&gt;
+        (?-i)\e                                                                                   # An Escape
+        \[                                                                                        # Followed by a bracket
+        (?&lt;ParameterBytes&gt;[\d\:\;\&lt;\=\&gt;\?]{0,})                                                   # Followed by zero or more parameter  
+        bytes
+        (?&lt;IntermediateBytes&gt;[\s\!\"\#\$\%\&amp;\'\(\)\*\+\,\-\.\/]{0,})                              # Followed by zero or more 
+        intermediate bytes
+        (?&lt;FinalByte&gt;[\@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\\\]\^_\`abcdefghijklmnopqrstuvwxyz\{\|\}\~]) # Followed by a final byte
+        
+        )                
+'@)
         $esc = [char]0x1b
         $standardColors = 'Black', 'Red', 'Green', 'Yellow', 'Blue','Magenta', 'Cyan', 'White'
         $brightColors   = 'BrightBlack', 'BrightRed', 'BrightGreen', 'BrightYellow', 'BrightBlue','BrightMagenta', 'BrightCyan', 'BrightWhite'
@@ -1227,6 +1249,10 @@ if ($Request -or $Host.UI.SupportsHTML) {
                 elseif ($canUseANSI) {'' +$esc + "[21m" }
             }
 
+            if ($Alignment -and $canUseHTML) {
+                "display:block;text-align:$($Alignment.ToLower())"
+            }
+
             if ($Link) {
                 if ($canUseHTML) { 
                     # Hyperlinks need to be a nested element
@@ -1257,13 +1283,39 @@ if ($Request -or $Host.UI.SupportsHTML) {
     }
 
     process {
+        $inputObjectAsString =
+            "$(if ($inputObject) { $inputObject | Out-String})".Trim()
+
+        $inputObjectAsString = 
+            if ($Alignment -and -not $canUseHTML) {
+                (@(foreach ($inputObjectLine in ($inputObjectAsString -split '(?&gt;\r\n|\n)')) {
+                    $inputObjectLength = $ansiCode.Replace($inputObjectLine, '').Length
+                    if ($inputObjectLength -lt $LineLength) {
+                        if ($Alignment -eq 'Left') {
+                            $inputObjectLine
+                        } elseif ($Alignment -eq 'Right') {
+                            (' ' * ($LineLength - $inputObjectLength)) + $inputObjectLine                            
+                        } else {
+                            $half = ($LineLength - $inputObjectLength)/2
+                            (' ' * [Math]::Floor($half)) + $inputObjectLine +
+                            (' ' * [Math]::Ceiling($half))
+                        }
+                    }
+                    else {
+                        $inputObjectLine
+                    }
+                }) -join [Environment]::NewLine) + [Environment]::newline
+            } else {
+                $inputObjectAsString
+            }
+
         $allOutput +=
             if ($header) {
-                "$header" + "$(if ($inputObject) { $inputObject | Out-String})".Trim()
+                "$header" + $inputObjectAsString
             }
             elseif ($inputObject) {
-                ($inputObject | Out-String).Trim()
-            }        
+                $inputObjectAsString
+            }
     }
 
     end {

--- a/EZOut.format.ps1xml
+++ b/EZOut.format.ps1xml
@@ -1027,9 +1027,9 @@ if ($Request -or $Host.UI.SupportsHTML) {
     [switch]$Invert,
 
     # If provided, will create a hyperlink to a given uri
-    [Alias('Link')]
+    [Alias('Hyperlink', 'Href')]
     [uri]
-    $Hyperlink,
+    $Link,
 
     # If set, will not clear formatting
     [switch]$NoClear
@@ -1650,6 +1650,7 @@ $BackgroundColor
 
     # If set, will create a link.  The -InputObject will be used as the link content    
     [Parameter(ValueFromPipelineByPropertyName)]
+    [Alias('Hyperlink', 'Href')]
     [string]
     $Link,
 

--- a/EZOut.psd1
+++ b/EZOut.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     ModuleToProcess = 'EZOut.psm1'
-    ModuleVersion = '1.9.8'
+    ModuleVersion = '1.9.9'
     GUID = 'cef786f0-8a0b-4a5d-a2c6-b433095354cd'
     Author = 'James Brundage'
     CompanyName = 'Start-Automating'
@@ -65,6 +65,14 @@
 
             Tags = '.ps1xml', 'Format','Output','Types', 'Colorized'
             ReleaseNotes = @'
+## 1.9.9:
+
+* Format-RichText -Hyperlink/-Link/-HRef now works (Fixes #93)
+* Format-RichText now supports -Alignment and -LineLength (Fixes #45)
+* GitHub Action no longer output extra information (Fixes #98)
+
+---
+
 ## 1.9.8:
 
 * Format-RichText now supports -Hyperlink (Fixes #93)

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -1204,3 +1204,21 @@ describe 'Format-Hashtable' {
         Format-Hashtable -InputObject @{a='a'} | Should -Match "^\@\{\s+a\s=\s'a'\s+}"
     }
 }
+
+describe 'Format-RichText' {
+    it 'Can format rich text' {
+        Format-RichText -ForegroundColor success -InputObject 'yay' | Should -Match '\e\[1;32'
+    }
+
+    it 'Can format any RGB color' {
+        $r, $g, $b  =  foreach ($n in 1..3) { Get-Random -Minimum 0 -Maximum 255 }
+        $rgb = "#{0:x2}{1:x2}{2:x2}" -f $r,$g,$b
+        Format-RichText -InputObject $rgb -ForegroundColor $rgb | 
+            Should -Match "^\e\[38;2;$r;$g;$b"
+    }
+
+    it 'Can make a hyperlink' {
+        Format-RichText -Hyperlink https://github.com/StartAutomating/EZOut -InputObject EZOut |
+            Should -Match '^\e\[8;;'
+    }
+}

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -438,13 +438,13 @@ describe "Write-FormatCustomView" {
         [PSCustomObject]@{PSTypeName=$tn;n=1} | Out-String | should -Belike '*This is true*'
     }
 
-    it "Will render an -Action that has only one token, which is a literal string, as <Text>" {
+    it "Will render an -Action that has only one token, which is a literal string, as a Text element" {
         $fv = Write-formatCustomview -Action { "foobar" }
         $fvXml = [xml]$fv
         $fvXml.CustomControl.CustomEntries.CustomEntry.CustomItem.Text | should -Be foobar
     }
 
-    it "Will render an -Action that uses the mythical command Write-NewLine will become a <Newline/>" {
+    it "Will render an -Action that uses the mythical command Write-NewLine will become a Newline element" {
         $fv = Write-FormatCustomView -Action { Write-NewLine }
         $fvXml = [xml]$fv
         if (-not $fvXml.CustomControl.CustomEntries.CustomEntry.CustomItem.ChildNodes[0].Name -eq 'Newline') {
@@ -470,7 +470,7 @@ describe "Write-FormatCustomView" {
             Add-FormatData
 
 
-        [PSCustomObject]@{PSTypeName='HostAwareFormatter';N=1} | Out-String | should -Belike "*normal host*"
+        [PSCustomObject]@{PSTypeName='HostAwareFormatter';N=1} | Out-String | should -Belike "*normal*host*"
     }
 
     it 'Can use a -ViewCondition with a -ViewSelectionSet to match multiple typenames (piping is still required)' {
@@ -486,7 +486,7 @@ describe "Write-FormatCustomView" {
             Add-FormatData
 
 
-        [PSCustomObject]@{PSTypeName='HostAwareFormatter';N=1} | Out-String | should -Belike "*normal host*"
+        [PSCustomObject]@{PSTypeName='HostAwareFormatter';N=1} | Out-String | should -Belike "*normal*host*"
     }
 
     it 'Can just run a command with no parameters in -Action' {
@@ -1022,7 +1022,7 @@ describe 'Add-FormatData' {
                 Out-FormatData  |
                 Add-FormatData -PassThru |
                 Select-Object -ExpandProperty Name |
-                should match 'FormatModule\d+'
+                should -Match 'FormatModule\d+'
         }
     }
 }

--- a/EZOut.tests.ps1
+++ b/EZOut.tests.ps1
@@ -1219,6 +1219,18 @@ describe 'Format-RichText' {
 
     it 'Can make a hyperlink' {
         Format-RichText -Hyperlink https://github.com/StartAutomating/EZOut -InputObject EZOut |
-            Should -Match '^\e\[8;;'
+            Should -Match '^\e\]8m;;'
+    }
+
+    it 'Can make text bold' {
+        Format-RichText -InputObject "bold" -Bold | Should -Match '\e\[1'
+    }
+
+    it 'Can make text italic' {
+        Format-RichText -InputObject 'italic' -Italic | Should -Match '\e\[2'
+    }
+
+    it 'Can make text underlined' {
+        Format-RichText -InputObject 'underline' -Underline | Should -Match '\e\[4'
     }
 }

--- a/Format-RichText.ps1
+++ b/Format-RichText.ps1
@@ -265,14 +265,14 @@ function Format-RichText
                 elseif ($canUseANSI) {'' +$esc + "[21m" }
             }
 
-            if ($Hyperlink) {
+            if ($Link) {
                 if ($canUseHTML) { 
                     # Hyperlinks need to be a nested element
                     # so we will not add it to style attributes for HTML
                 }
                 elseif ($canUseANSI) {
                     # For ANSI,
-                    '' + $esc + ']8m;;' + $Hyperlink + $esc + '\'   
+                    '' + $esc + ']8m;;' + $Link + $esc + '\'   
                 }
             }
             
@@ -285,8 +285,8 @@ function Format-RichText
                 )$(
                     if ($cssClasses) { " class='$($cssClasses -join ' ')'"}
                 )>" + $(
-                    if ($Hyperlink) {
-                        "<a href='$hyperLink'>"
+                    if ($Link) {
+                        "<a href='$link'>"
                     }
                 )
             } elseif ($canUseANSI) {
@@ -309,7 +309,7 @@ function Format-RichText
         if (-not $NoClear) {
             $allOutput += 
                 if ($canUseHTML) {
-                    if ($Hyperlink) {
+                    if ($Link) {
                         "</a>"
                     }
                     "</span>"
@@ -343,7 +343,7 @@ function Format-RichText
                         "$esc[49m"
                     }
 
-                    if ($Hyperlink) {
+                    if ($Link) {
                         "$esc]8;;$esc\"
                     }
                 

--- a/Format-RichText.ps1
+++ b/Format-RichText.ps1
@@ -13,7 +13,7 @@ function Format-RichText
     .Notes
         Stylized Output works in two contexts at present:
         * Rich consoles (Windows Terminal, PowerShell.exe, Pwsh.exe) (when $host.UI.SupportsVirtualTerminal)
-        * Web pages (Based off the presence of a $Request variable, or when $host.UI.SupportsHTML (you must add this property to $host.UI))        
+        * Web pages (Based off the presence of a $Request variable, or when $host.UI.SupportsHTML (you must add this property to $host.UI))
     #>
     [Management.Automation.Cmdlet("Format","Object")]
     [ValidateScript({
@@ -70,7 +70,16 @@ function Format-RichText
     $Link,
 
     # If set, will not clear formatting
-    [switch]$NoClear
+    [switch]$NoClear,
+
+    # The alignment.  Defaulting to Left.
+    # Setting an alignment will pad the empty space of each line.
+    [ValidateSet('Left','Right','Center')]
+    [string]
+    $Alignment,
+
+    # The length of a line.  By default, the buffer width
+    [int]$LineLength = $($host.UI.RawUI.BufferSize.Width)
     )    
 
     begin {
@@ -80,6 +89,19 @@ function Format-RichText
             Output='';Error='BrightRed';Warning='BrightYellow';
             Verbose='BrightCyan';Debug='Yellow';Progress='Cyan';
             Success='BrightGreen';Failure='Red';Default=''}
+
+        $ansiCode = [Regex]::new(@'
+        (?<ANSI_Code>
+        (?-i)\e                                                                                   # An Escape
+        \[                                                                                        # Followed by a bracket
+        (?<ParameterBytes>[\d\:\;\<\=\>\?]{0,})                                                   # Followed by zero or more parameter  
+        bytes
+        (?<IntermediateBytes>[\s\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/]{0,})                              # Followed by zero or more 
+        intermediate bytes
+        (?<FinalByte>[\@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\\\]\^_\`abcdefghijklmnopqrstuvwxyz\{\|\}\~]) # Followed by a final byte
+        
+        )                
+'@)
         $esc = [char]0x1b
         $standardColors = 'Black', 'Red', 'Green', 'Yellow', 'Blue','Magenta', 'Cyan', 'White'
         $brightColors   = 'BrightBlack', 'BrightRed', 'BrightGreen', 'BrightYellow', 'BrightBlue','BrightMagenta', 'BrightCyan', 'BrightWhite'
@@ -265,6 +287,10 @@ function Format-RichText
                 elseif ($canUseANSI) {'' +$esc + "[21m" }
             }
 
+            if ($Alignment -and $canUseHTML) {
+                "display:block;text-align:$($Alignment.ToLower())"
+            }
+
             if ($Link) {
                 if ($canUseHTML) { 
                     # Hyperlinks need to be a nested element
@@ -295,13 +321,39 @@ function Format-RichText
     }
 
     process {
+        $inputObjectAsString =
+            "$(if ($inputObject) { $inputObject | Out-String})".Trim()
+
+        $inputObjectAsString = 
+            if ($Alignment -and -not $canUseHTML) {
+                (@(foreach ($inputObjectLine in ($inputObjectAsString -split '(?>\r\n|\n)')) {
+                    $inputObjectLength = $ansiCode.Replace($inputObjectLine, '').Length
+                    if ($inputObjectLength -lt $LineLength) {
+                        if ($Alignment -eq 'Left') {
+                            $inputObjectLine
+                        } elseif ($Alignment -eq 'Right') {
+                            (' ' * ($LineLength - $inputObjectLength)) + $inputObjectLine                            
+                        } else {
+                            $half = ($LineLength - $inputObjectLength)/2
+                            (' ' * [Math]::Floor($half)) + $inputObjectLine +
+                            (' ' * [Math]::Ceiling($half))
+                        }
+                    }
+                    else {
+                        $inputObjectLine
+                    }
+                }) -join [Environment]::NewLine) + [Environment]::newline
+            } else {
+                $inputObjectAsString
+            }
+
         $allOutput +=
             if ($header) {
-                "$header" + "$(if ($inputObject) { $inputObject | Out-String})".Trim()
+                "$header" + $inputObjectAsString
             }
             elseif ($inputObject) {
-                ($inputObject | Out-String).Trim()
-            }        
+                $inputObjectAsString
+            }
     }
 
     end {

--- a/Format-RichText.ps1
+++ b/Format-RichText.ps1
@@ -73,7 +73,7 @@ function Format-RichText
     [switch]$NoClear,
 
     # The alignment.  Defaulting to Left.
-    # Setting an alignment will pad the empty space of each line.
+    # Setting an alignment will pad the remaining space on each line.
     [ValidateSet('Left','Right','Center')]
     [string]
     $Alignment,

--- a/GitHub/Actions/EZOutAction.ps1
+++ b/GitHub/Actions/EZOutAction.ps1
@@ -181,7 +181,7 @@ if ($EZOutScript) {
         Out-Host
 }
 $EZOutScriptTook = [Datetime]::Now - $EZOutScriptStart
-"::set-output name=EZOutScriptRuntime::$($EZOutScriptTook.TotalMilliseconds)"   | Out-Host
+# "::set-output name=EZOutScriptRuntime::$($EZOutScriptTook.TotalMilliseconds)"   | Out-Host
 
 $EZOutPS1Start = [DateTime]::Now
 $EZOutPS1List  = @()
@@ -208,9 +208,9 @@ if (-not $SkipEZOutPS1) {
 
 $EZOutPS1EndStart = [DateTime]::Now
 $EZOutPS1Took = [Datetime]::Now - $EZOutPS1Start
-"::set-output name=EZOutPS1Count::$($EZOutPS1List.Length)"   | Out-Host
-"::set-output name=EZOutPS1Files::$($EZOutPS1List -join ';')"   | Out-Host
-"::set-output name=EZOutPS1Runtime::$($EZOutPS1Took.TotalMilliseconds)"   | Out-Host
+# "::set-output name=EZOutPS1Count::$($EZOutPS1List.Length)"   | Out-Host
+# "::set-output name=EZOutPS1Files::$($EZOutPS1List -join ';')"   | Out-Host
+# "::set-output name=EZOutPS1Runtime::$($EZOutPS1Took.TotalMilliseconds)"   | Out-Host
 if ($CommitMessage -or $anyFilesChanged) {
     if ($CommitMessage) {
         dir $env:GITHUB_WORKSPACE -Recurse |

--- a/action.yml
+++ b/action.yml
@@ -28,20 +28,6 @@ inputs:
 branding: 
   icon: code
   color: blue
-outputs: 
-  
-    EZOutScriptRuntime: 
-      description: The time it took the .EZOutScript parameter to run
-      value: ${{steps.EZOutAction.outputs.EZOutScriptRuntime}}
-    EZOutPS1Runtime: 
-      description: The time it took all .EZOut.ps1 files to run
-      value: ${{steps.EZOutAction.outputs.EZOutPS1Runtime}}
-    EZOutPS1Files: 
-      description: The .EZOut.ps1 files that were run (separated by semicolons)
-      value: ${{steps.EZOutAction.outputs.EZOutPS1Files}}
-    EZOutPS1Count: 
-      description: The number of .EZOut.ps1 files that were run
-      value: ${{steps.EZOutAction.outputs.EZOutPS1Count}}
 runs: 
   using: composite
   steps: 
@@ -49,12 +35,12 @@ runs:
       id: EZOutAction
       shell: pwsh
       env: 
-        CommitMessage: ${{inputs.CommitMessage}}
         ModuleName: ${{inputs.ModuleName}}
         UserName: ${{inputs.UserName}}
-        EZOutScript: ${{inputs.EZOutScript}}
         UserEmail: ${{inputs.UserEmail}}
         SkipEZOutPS1: ${{inputs.SkipEZOutPS1}}
+        CommitMessage: ${{inputs.CommitMessage}}
+        EZOutScript: ${{inputs.EZOutScript}}
       run: |
         $Parameters = @{}
         $Parameters.EZOutScript = ${env:EZOutScript}
@@ -253,7 +239,7 @@ runs:
                 Out-Host
         }
         $EZOutScriptTook = [Datetime]::Now - $EZOutScriptStart
-        "::set-output name=EZOutScriptRuntime::$($EZOutScriptTook.TotalMilliseconds)"   | Out-Host
+        # "::set-output name=EZOutScriptRuntime::$($EZOutScriptTook.TotalMilliseconds)"   | Out-Host
         
         $EZOutPS1Start = [DateTime]::Now
         $EZOutPS1List  = @()
@@ -280,9 +266,9 @@ runs:
         
         $EZOutPS1EndStart = [DateTime]::Now
         $EZOutPS1Took = [Datetime]::Now - $EZOutPS1Start
-        "::set-output name=EZOutPS1Count::$($EZOutPS1List.Length)"   | Out-Host
-        "::set-output name=EZOutPS1Files::$($EZOutPS1List -join ';')"   | Out-Host
-        "::set-output name=EZOutPS1Runtime::$($EZOutPS1Took.TotalMilliseconds)"   | Out-Host
+        # "::set-output name=EZOutPS1Count::$($EZOutPS1List.Length)"   | Out-Host
+        # "::set-output name=EZOutPS1Files::$($EZOutPS1List -join ';')"   | Out-Host
+        # "::set-output name=EZOutPS1Runtime::$($EZOutPS1Took.TotalMilliseconds)"   | Out-Host
         if ($CommitMessage -or $anyFilesChanged) {
             if ($CommitMessage) {
                 dir $env:GITHUB_WORKSPACE -Recurse |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.9.9:
+
+* Format-RichText -Hyperlink/-Link/-HRef now works (Fixes #93)
+* Format-RichText now supports -Alignment and -LineLength (Fixes #45)
+* GitHub Action no longer output extra information (Fixes #98)
+
+---
+
 ## 1.9.8:
 
 * Format-RichText now supports -Hyperlink (Fixes #93)

--- a/docs/Format-RichText.md
+++ b/docs/Format-RichText.md
@@ -219,7 +219,7 @@ If set, will invert text
 
 
 ---
-#### **Hyperlink**
+#### **Link**
 
 If provided, will create a hyperlink to a given uri
 
@@ -262,7 +262,7 @@ If set, will not clear formatting
 ---
 ### Syntax
 ```PowerShell
-Format-RichText [[-InputObject] <PSObject>] [[-ForegroundColor] <String>] [[-BackgroundColor] <String>] [-Bold] [-Italic] [-Faint] [-Hide] [-Blink] [-Strikethru] [-Underline] [-DoubleUnderline] [-Invert] [[-Hyperlink] <Uri>] [-NoClear] [<CommonParameters>]
+Format-RichText [[-InputObject] <PSObject>] [[-ForegroundColor] <String>] [[-BackgroundColor] <String>] [-Bold] [-Italic] [-Faint] [-Hide] [-Blink] [-Strikethru] [-Underline] [-DoubleUnderline] [-Invert] [[-Link] <Uri>] [-NoClear] [<CommonParameters>]
 ```
 ---
 ### Notes

--- a/docs/Format-RichText.md
+++ b/docs/Format-RichText.md
@@ -253,6 +253,49 @@ If set, will not clear formatting
 
 
 ---
+#### **Alignment**
+
+The alignment.  Defaulting to Left.
+Setting an alignment will pad the remaining space on each line.
+
+
+
+Valid Values:
+
+* Left
+* Right
+* Center
+
+
+
+> **Type**: ```[String]```
+
+> **Required**: false
+
+> **Position**: 5
+
+> **PipelineInput**:false
+
+
+
+---
+#### **LineLength**
+
+The length of a line.  By default, the buffer width
+
+
+
+> **Type**: ```[Int32]```
+
+> **Required**: false
+
+> **Position**: 6
+
+> **PipelineInput**:false
+
+
+
+---
 ### Outputs
 * [String](https://learn.microsoft.com/en-us/dotnet/api/System.String)
 
@@ -262,7 +305,7 @@ If set, will not clear formatting
 ---
 ### Syntax
 ```PowerShell
-Format-RichText [[-InputObject] <PSObject>] [[-ForegroundColor] <String>] [[-BackgroundColor] <String>] [-Bold] [-Italic] [-Faint] [-Hide] [-Blink] [-Strikethru] [-Underline] [-DoubleUnderline] [-Invert] [[-Link] <Uri>] [-NoClear] [<CommonParameters>]
+Format-RichText [[-InputObject] <PSObject>] [[-ForegroundColor] <String>] [[-BackgroundColor] <String>] [-Bold] [-Italic] [-Faint] [-Hide] [-Blink] [-Strikethru] [-Underline] [-DoubleUnderline] [-Invert] [[-Link] <Uri>] [-NoClear] [[-Alignment] <String>] [[-LineLength] <Int32>] [<CommonParameters>]
 ```
 ---
 ### Notes

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,3 +195,4 @@ Get-Module EZOut | Format-Custom
 
 
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,4 +195,3 @@ Get-Module EZOut | Format-Custom
 
 
 
-


### PR DESCRIPTION
## 1.9.9:

* Format-RichText -Hyperlink/-Link/-HRef now works (Fixes #93)
* Format-RichText now supports -Alignment and -LineLength (Fixes #45)
* GitHub Action no longer output extra information (Fixes #98)

---